### PR TITLE
Disable non-enabed streams in dropdowns.

### DIFF
--- a/editor/style/style.css
+++ b/editor/style/style.css
@@ -845,3 +845,13 @@ main {
   margin: 0;
   color: #666;
 }
+
+/* Styling for disabled options in stream target dropdowns */
+option[disabled] {
+  color: #999;
+  font-style: italic;
+}
+
+select option[disabled] {
+  background-color: #f5f5f5;
+}


### PR DESCRIPTION
Determine which streams are enabled and disable others in the dropdowns that allow the UI editor to specify targets. Closes #422.