### PR TITLE
Equipment percent increase by units bug

### DIFF
--- a/editor/test/test_integration.js
+++ b/editor/test/test_integration.js
@@ -1156,8 +1156,9 @@ function buildIntegrationTests() {
           assert.ok(false, "Expected UnsupportedOperationException for substance displacement");
         } catch (e) {
           // Check that the error message contains our expected displacement blocking message
-          const expectedMessage = "Displacement target 'sub_b' is not currently supported in recycling operations";
-          assert.ok(e.message.includes(expectedMessage), 
+          const expectedMessage = "Displacement target 'sub_b' is not currently supported in " +
+            "recycling operations";
+          assert.ok(e.message.includes(expectedMessage),
             "Should throw exception for substance displacement: " + e.message);
         }
 

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -73,10 +73,6 @@ application {
 // JUnit target for all tests.
 test {
   useJUnitPlatform()
-  testLogging {
-    events "skipped", "failed"
-    exceptionFormat = "full"
-  }
 }
 
 // JUnit resource assets for tests.

--- a/engine/src/test/java/org/kigalisim/validate/ChangeLiveTests.java
+++ b/engine/src/test/java/org/kigalisim/validate/ChangeLiveTests.java
@@ -198,21 +198,30 @@ public class ChangeLiveTests {
 
     // Expected values: 500, 525, 551.25, 578.8125, 607.753125 (5% each year)
     // Actual problematic values: 500, 604.8, 750.8, 946.5, 1204.0
-    
+
     // Check year 2 import value - should be 525 units, not 604.8
     EngineResult year2Result = LiveTestsUtil.getResult(resultsList.stream(), 2, "RAC1 - Resac1", "R-410A");
     assertNotNull(year2Result, "Should have result for RAC1 - Resac1/R-410A in year 2");
-    
-    // Convert to units for verification (525 units * 1 kg/unit = 525 kg)
-    assertEquals(525.0, year2Result.getImport().getValue().doubleValue(), 0.0001,
-        "Year 2 import should be 525 kg (525 units * 1 kg/unit)");
-    
-    // Check year 3 import value - should be 551.25 units  
-    EngineResult year3Result = LiveTestsUtil.getResult(resultsList.stream(), 3, "RAC1 - Resac1", "R-410A");
-    assertNotNull(year3Result, "Should have result for RAC1 - Resac1/R-410A in year 3");
-    
-    // Convert to units for verification (551.25 units * 1 kg/unit = 551.25 kg)
-    assertEquals(551.25, year3Result.getImport().getValue().doubleValue(), 0.0001,
-        "Year 3 import should be 551.25 kg (551.25 units * 1 kg/unit)");
+
+    // Check equipment values against expected progression with 5% retirement and 5% import growth
+    // Expected: 1450, 1903, 2359, 2820, 3286 units (with rounding)
+    final EngineResult year1Result = LiveTestsUtil.getResult(resultsList.stream(), 1, "RAC1 - Resac1", "R-410A");
+    assertEquals(1450.0, year1Result.getPopulation().getValue().doubleValue(), 5.0,
+        "Year 1 equipment should be ~1450 units");
+
+    assertEquals(1903.0, year2Result.getPopulation().getValue().doubleValue(), 5.0,
+        "Year 2 equipment should be ~1903 units");
+
+    final EngineResult year3Result = LiveTestsUtil.getResult(resultsList.stream(), 3, "RAC1 - Resac1", "R-410A");
+    assertEquals(2359.0, year3Result.getPopulation().getValue().doubleValue(), 5.0,
+        "Year 3 equipment should be ~2359 units");
+
+    final EngineResult year4Result = LiveTestsUtil.getResult(resultsList.stream(), 4, "RAC1 - Resac1", "R-410A");
+    assertEquals(2820.0, year4Result.getPopulation().getValue().doubleValue(), 5.0,
+        "Year 4 equipment should be ~2820 units");
+
+    final EngineResult year5Result = LiveTestsUtil.getResult(resultsList.stream(), 5, "RAC1 - Resac1", "R-410A");
+    assertEquals(3286.0, year5Result.getPopulation().getValue().doubleValue(), 5.0,
+        "Year 5 equipment should be ~3286 units");
   }
 }

--- a/engine/src/test/java/org/kigalisim/validate/ChangeLiveTests.java
+++ b/engine/src/test/java/org/kigalisim/validate/ChangeLiveTests.java
@@ -206,21 +206,23 @@ public class ChangeLiveTests {
     // Check equipment values against expected progression with 5% retirement and 5% import growth
     // Expected: 1450, 1903, 2359, 2820, 3286 units (with rounding)
     final EngineResult year1Result = LiveTestsUtil.getResult(resultsList.stream(), 1, "RAC1 - Resac1", "R-410A");
+    
+    final EngineResult year3Result = LiveTestsUtil.getResult(resultsList.stream(), 3, "RAC1 - Resac1", "R-410A");
+    final EngineResult year4Result = LiveTestsUtil.getResult(resultsList.stream(), 4, "RAC1 - Resac1", "R-410A");
+    final EngineResult year5Result = LiveTestsUtil.getResult(resultsList.stream(), 5, "RAC1 - Resac1", "R-410A");
+    
     assertEquals(1450.0, year1Result.getPopulation().getValue().doubleValue(), 5.0,
         "Year 1 equipment should be ~1450 units");
 
     assertEquals(1903.0, year2Result.getPopulation().getValue().doubleValue(), 5.0,
         "Year 2 equipment should be ~1903 units");
 
-    final EngineResult year3Result = LiveTestsUtil.getResult(resultsList.stream(), 3, "RAC1 - Resac1", "R-410A");
     assertEquals(2359.0, year3Result.getPopulation().getValue().doubleValue(), 5.0,
         "Year 3 equipment should be ~2359 units");
 
-    final EngineResult year4Result = LiveTestsUtil.getResult(resultsList.stream(), 4, "RAC1 - Resac1", "R-410A");
     assertEquals(2820.0, year4Result.getPopulation().getValue().doubleValue(), 5.0,
         "Year 4 equipment should be ~2820 units");
 
-    final EngineResult year5Result = LiveTestsUtil.getResult(resultsList.stream(), 5, "RAC1 - Resac1", "R-410A");
     assertEquals(3286.0, year5Result.getPopulation().getValue().doubleValue(), 5.0,
         "Year 5 equipment should be ~3286 units");
   }

--- a/engine/src/test/java/org/kigalisim/validate/ChangeLiveTests.java
+++ b/engine/src/test/java/org/kigalisim/validate/ChangeLiveTests.java
@@ -178,4 +178,41 @@ public class ChangeLiveTests {
     // Should have 10 trials * 2 years = 20 results
     assertEquals(20, resultsList.size(), "Should have 20 results (10 trials * 2 years)");
   }
+
+  /**
+   * Test that change operations properly respect units when last specified value was in units.
+   * This tests the bug where recharge causes change operations to use kg instead of units.
+   */
+  @Test
+  public void testChangeRechargeUnitsRespected() throws IOException {
+    // Load and parse the QTA file
+    String qtaPath = "../examples/change_recharge_units_bug.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    // Run the scenario using KigaliSimFacade
+    String scenarioName = "S1";
+    Stream<EngineResult> results = KigaliSimFacade.runScenario(program, scenarioName, progress -> {});
+
+    List<EngineResult> resultsList = results.collect(Collectors.toList());
+
+    // Expected values: 500, 525, 551.25, 578.8125, 607.753125 (5% each year)
+    // Actual problematic values: 500, 604.8, 750.8, 946.5, 1204.0
+    
+    // Check year 2 import value - should be 525 units, not 604.8
+    EngineResult year2Result = LiveTestsUtil.getResult(resultsList.stream(), 2, "RAC1 - Resac1", "R-410A");
+    assertNotNull(year2Result, "Should have result for RAC1 - Resac1/R-410A in year 2");
+    
+    // Convert to units for verification (525 units * 1 kg/unit = 525 kg)
+    assertEquals(525.0, year2Result.getImport().getValue().doubleValue(), 0.0001,
+        "Year 2 import should be 525 kg (525 units * 1 kg/unit)");
+    
+    // Check year 3 import value - should be 551.25 units  
+    EngineResult year3Result = LiveTestsUtil.getResult(resultsList.stream(), 3, "RAC1 - Resac1", "R-410A");
+    assertNotNull(year3Result, "Should have result for RAC1 - Resac1/R-410A in year 3");
+    
+    // Convert to units for verification (551.25 units * 1 kg/unit = 551.25 kg)
+    assertEquals(551.25, year3Result.getImport().getValue().doubleValue(), 0.0001,
+        "Year 3 import should be 551.25 kg (551.25 units * 1 kg/unit)");
+  }
 }

--- a/engine/src/test/java/org/kigalisim/validate/RechargeLiveTests.java
+++ b/engine/src/test/java/org/kigalisim/validate/RechargeLiveTests.java
@@ -509,7 +509,8 @@ public class RechargeLiveTests {
         + (combinedR600a2035.getDomestic().getValue().doubleValue() + combinedR600a2035.getImport().getValue().doubleValue());
 
     // Expected: Recycling scenario produces consistent consumption
-    assertEquals(32853.44, recyclingTotalConsumption, 1.0, "Recycling scenario total consumption should be ~32,853 kg");
+    // Updated after fixing sales percentage change bug - was 32,853 kg with buggy behavior
+    assertEquals(69978.42, recyclingTotalConsumption, 1.0, "Recycling scenario total consumption should be ~69,978 kg");
 
     // Expected: Combined policies (recycling + cap) should consume LESS than recycling alone
     // Cap policies should reduce overall consumption when applied on top of recycling
@@ -577,7 +578,8 @@ public class RechargeLiveTests {
         + (combinedR600a2035.getDomestic().getValue().doubleValue() + combinedR600a2035.getImport().getValue().doubleValue());
 
     // Expected: Recycling scenario produces consistent consumption
-    assertEquals(32853.44, recyclingTotalConsumption, 1.0, "Recycling scenario total consumption should be ~32,853 kg");
+    // Updated after fixing sales percentage change bug - was 32,853 kg with buggy behavior
+    assertEquals(69978.42, recyclingTotalConsumption, 1.0, "Recycling scenario total consumption should be ~69,978 kg");
 
     // Expected: Combined policies (recycling + cap) should consume LESS than recycling alone
     // Cap policies should reduce overall consumption when applied on top of recycling

--- a/examples/change_recharge_units_bug.qta
+++ b/examples/change_recharge_units_bug.qta
@@ -1,0 +1,29 @@
+start default
+
+  define application "RAC1 - Resac1"
+  
+    uses substance "R-410A"
+      enable import
+      initial charge with 0 kg / unit for domestic
+      initial charge with 1 kg / unit for import
+      initial charge with 0 kg / unit for export
+      equals 2082 tCO2e / kg
+      equals 1500 kwh / unit
+      set import to 500 units during year 1
+      set priorEquipment to 1000 units during year 1
+      change import by 5 % during years 2 to 10
+      retire 5 % / year
+      recharge 8 % / year with 1 kg / unit
+    end substance
+  
+  end application
+
+end default
+
+
+start simulations
+
+  simulate "S1"
+  from years 1 to 5
+
+end simulations


### PR DESCRIPTION
Fix issue when sales are specified in equipment (units of equipment, not kg or mt) and a percentage change is applied on top. Due to changes supporting automatic re-calculation of recharge added for end of life recycling, this percent change was including recharge when it should only have included the new equipment (initial charge).