### PR TITLE
Expand tests for replace.

### DIFF
--- a/beta_changelog.md
+++ b/beta_changelog.md
@@ -10,33 +10,17 @@ Hello! Thank you for your help in refining Kigali Sim. During the beta testing p
 
 Finally, we want to again express our gratitude for your feedback and time.
 
-## Needs Discussion
-
-Information about issues or discussions still underway, with target completion before December launch.
-
-### Servicing of new equipment
-
-**Status:** In discussion
-
-Some prior modeling efforts outside of Kigali Sim would apply servicing (top up or repair) to all equipment in a year while others would only apply it to equipment over a certain age, avoiding maintenance on equipment just sold. Kigali Sim currently takes the later approach where only existing equipment from previous years are subject to servicing and new equipment are not assumed to need recharge or repair. Multiple proposals have been made:
-
-- Keep the current logic which only applies servicing to existing equipment from previous years.
-- Use simpler logic where recharge applies to all equipment not old equipment to simplify manual calculations of users validating Kigali Sim models using manual calculations.
-- Allow the user to specify which behavior is desired. However, this adds additional complexity to the tool and may lead to confusion when comparing results between Kigali Sim models.
-
-This is being discussed in [#469](https://github.com/SchmidtDSE/kigali-sim/issues/469) and we welcome feedback. Note that the default behavior of Kigali Sim is to retire old equipment and then recharge from the remaining population but this can be modified through [QubecTalk](https://kigalisim.org/guide/tutorial_07.html) code (see the editor tab for advanced capabilities).
-
-### Initial charge / recharge consumption options
-
-**Status:** In discussion
-
-In addition to the emissions radio button, there is discussion of adding initial charge and recharge options under consumption. In some ways these are redundant to the emissions optinos but with more unit conversions though it causes potential confusion when setting custom metrics and in understanding trade attribution.
-
-This is being discussed in [#490](https://github.com/SchmidtDSE/kigali-sim/issues/490). Please let us know what you think!
-
 ## Completed
 
 The following changes have been adopted and released.
+
+### Fix replace for mid-year equipment calcualtion
+
+**Status**: Released September 5, 2025
+
+**Classification**: Bug
+
+Prior testing caught an issue with cap operations but this was accidentially not extended to include replace operations. This caused issues with mid-year (or mid-timestep) recalculation of equipment. See [#522](https://github.com/SchmidtDSE/kigali-sim/pull/522). Automated tests added to prevent future issues.
 
 ### Add kgCO2e Option
 
@@ -161,3 +145,29 @@ We added end of life recycling after the [OEWG](https://ozone.unep.org/meetings/
 **Classification:** Enhancement
 
 Note that this was queued to go to deployment so the release date may be approximate. To improve accessibility shading and a non-color (outline) indicator are both used to show which tab is currently active. This was done for usability and accessibility.
+
+## Needs Discussion
+
+Information about issues or discussions still underway, with target completion before December launch.
+
+### Servicing of new equipment
+
+**Status:** In discussion
+
+Some prior modeling efforts outside of Kigali Sim would apply servicing (top up or repair) to all equipment in a year while others would only apply it to equipment over a certain age, avoiding maintenance on equipment just sold. Kigali Sim currently takes the later approach where only existing equipment from previous years are subject to servicing and new equipment are not assumed to need recharge or repair. Multiple proposals have been made:
+
+- Keep the current logic which only applies servicing to existing equipment from previous years.
+- Use simpler logic where recharge applies to all equipment not old equipment to simplify manual calculations of users validating Kigali Sim models using manual calculations.
+- Allow the user to specify which behavior is desired. However, this adds additional complexity to the tool and may lead to confusion when comparing results between Kigali Sim models.
+
+This is being discussed in [#469](https://github.com/SchmidtDSE/kigali-sim/issues/469) and we welcome feedback. Note that the default behavior of Kigali Sim is to retire old equipment and then recharge from the remaining population but this can be modified through [QubecTalk](https://kigalisim.org/guide/tutorial_07.html) code (see the editor tab for advanced capabilities).
+
+### Initial charge / recharge consumption options
+
+**Status:** In discussion
+
+In addition to the emissions radio button, there is discussion of adding initial charge and recharge options under consumption. In some ways these are redundant to the emissions optinos but with more unit conversions though it causes potential confusion when setting custom metrics and in understanding trade attribution.
+
+This is being discussed in [#490](https://github.com/SchmidtDSE/kigali-sim/issues/490). Please let us know what you think!
+
+

--- a/engine/src/main/java/org/kigalisim/engine/SingleThreadEngine.java
+++ b/engine/src/main/java/org/kigalisim/engine/SingleThreadEngine.java
@@ -845,7 +845,7 @@ public class SingleThreadEngine implements Engine {
       scope = originalScope;
 
       EngineNumber destinationVolumeChange = destinationUnitConverter.convert(unitsToReplace, "kg");
-      changeStreamWithoutReportingUnits(stream, destinationVolumeChange, Optional.empty(), Optional.of(destinationScope));
+      changeStreamWithDisplacementContext(stream, destinationVolumeChange, destinationScope);
     } else {
       // For volume units, use the original logic
       UnitConverter unitConverter = EngineSupportUtils.createUnitConverterWithTotal(this, stream);
@@ -855,7 +855,7 @@ public class SingleThreadEngine implements Engine {
       changeStreamWithoutReportingUnits(stream, amountNegative, Optional.empty(), Optional.empty());
 
       Scope destinationScope = scope.getWithSubstance(destinationSubstance);
-      changeStreamWithoutReportingUnits(stream, amount, Optional.empty(), Optional.of(destinationScope));
+      changeStreamWithDisplacementContext(stream, amount, destinationScope);
     }
   }
 

--- a/engine/src/test/java/org/kigalisim/validate/ReplaceLiveTests.java
+++ b/engine/src/test/java/org/kigalisim/validate/ReplaceLiveTests.java
@@ -8,6 +8,7 @@ package org.kigalisim.validate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.List;
@@ -135,5 +136,90 @@ public class ReplaceLiveTests {
         "Consumption for substance b should be 375 tCO2e");
     assertEquals("tCO2e", resultB.getGhgConsumption().getUnits(),
         "Consumption units should be tCO2e");
+  }
+
+  /**
+   * Test tutorial_11.qta to verify replacement policy behavior.
+   * This test verifies that:
+   * 1. Total kg of sales remains the same between BAU and Replacement scenarios at 2030
+   * 2. Total equipment populations remain the same between BAU and Replacement at 2030
+   * 3. Recharge emissions in BAU should be higher than in Replacement (not lower)
+   */
+  @Test
+  public void testTutorial11Replacement() throws IOException {
+    // Load and parse the QTA file
+    String qtaPath = "../examples/tutorial_11.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    // Run BAU scenario
+    Stream<EngineResult> bauResults = KigaliSimFacade.runScenario(program, "BAU", progress -> {});
+    List<EngineResult> bauResultsList = bauResults.collect(Collectors.toList());
+
+    // Run Replacement scenario
+    Stream<EngineResult> replacementResults = KigaliSimFacade.runScenario(program, "Replacement", progress -> {});
+    List<EngineResult> replacementResultsList = replacementResults.collect(Collectors.toList());
+
+    // Get year 2030 results (year 6 since simulation starts at 2025)
+    int targetYear = 2030;
+    
+    // BAU results for 2030
+    EngineResult bauHfc134a = LiveTestsUtil.getResult(bauResultsList.stream(), targetYear, 
+        "Domestic Refrigeration", "HFC-134a");
+    EngineResult bauR600a = LiveTestsUtil.getResult(bauResultsList.stream(), targetYear,
+        "Domestic Refrigeration", "R-600a");
+    
+    // Replacement results for 2030
+    EngineResult replacementHfc134a = LiveTestsUtil.getResult(replacementResultsList.stream(), targetYear,
+        "Domestic Refrigeration", "HFC-134a");
+    final EngineResult replacementR600a = LiveTestsUtil.getResult(replacementResultsList.stream(), targetYear,
+        "Domestic Refrigeration", "R-600a");
+
+    assertNotNull(bauHfc134a, "Should have BAU result for HFC-134a in 2030");
+    assertNotNull(bauR600a, "Should have BAU result for R-600a in 2030");
+    assertNotNull(replacementHfc134a, "Should have Replacement result for HFC-134a in 2030");
+    assertNotNull(replacementR600a, "Should have Replacement result for R-600a in 2030");
+
+    // Test 1: Total kg of sales should be the same between BAU and Replacement at 2030
+    double bauHfc134aSales = bauHfc134a.getDomestic().getValue().doubleValue();
+    double bauR600aSales = bauR600a.getDomestic().getValue().doubleValue();
+    double bauTotalSales = bauHfc134aSales + bauR600aSales;
+    
+    double replacementHfc134aSales = replacementHfc134a.getDomestic().getValue().doubleValue();
+    double replacementR600aSales = replacementR600a.getDomestic().getValue().doubleValue();
+    double replacementTotalSales = replacementHfc134aSales + replacementR600aSales;
+    
+    
+    assertEquals(bauTotalSales, replacementTotalSales, 0.01,
+        "Total kg of sales should be the same between BAU and Replacement scenarios at 2030");
+
+    // Test 2: Total equipment populations should be the same between BAU and Replacement at 2030
+    double bauHfc134aPopulation = bauHfc134a.getPopulation().getValue().doubleValue();
+    double bauR600aPopulation = bauR600a.getPopulation().getValue().doubleValue();
+    double bauTotalPopulation = bauHfc134aPopulation + bauR600aPopulation;
+    
+    double replacementHfc134aPopulation = replacementHfc134a.getPopulation().getValue().doubleValue();
+    double replacementR600aPopulation = replacementR600a.getPopulation().getValue().doubleValue();
+    double replacementTotalPopulation = replacementHfc134aPopulation + replacementR600aPopulation;
+    
+    
+    assertEquals(bauTotalPopulation, replacementTotalPopulation, 1.0,
+        "Total equipment populations should be the same between BAU and Replacement scenarios at 2030");
+
+    // Test 3: Recharge emissions in BAU should be higher than in Replacement
+    // Since HFC-134a has much higher GWP (1430 kgCO2e/kg) than R-600a (3 kgCO2e/kg),
+    // replacing some HFC-134a with R-600a should reduce recharge emissions
+    double bauHfc134aRecharge = bauHfc134a.getRechargeEmissions().getValue().doubleValue();
+    double bauR600aRecharge = bauR600a.getRechargeEmissions().getValue().doubleValue();
+    double bauTotalRechargeEmissions = bauHfc134aRecharge + bauR600aRecharge;
+    
+    double replacementHfc134aRecharge = replacementHfc134a.getRechargeEmissions().getValue().doubleValue();
+    double replacementR600aRecharge = replacementR600a.getRechargeEmissions().getValue().doubleValue();
+    double replacementTotalRechargeEmissions = replacementHfc134aRecharge + replacementR600aRecharge;
+    
+    
+    assertTrue(bauTotalRechargeEmissions > replacementTotalRechargeEmissions,
+        String.format("BAU recharge emissions (%.2f) should be higher than Replacement recharge emissions (%.2f), not lower",
+            bauTotalRechargeEmissions, replacementTotalRechargeEmissions));
   }
 }

--- a/examples/cap_displace_prior_equipment.qta
+++ b/examples/cap_displace_prior_equipment.qta
@@ -1,0 +1,50 @@
+start default
+
+  define application "Test App"
+  
+    uses substance "High-GWP"
+      enable domestic
+      initial charge with 0.15 kg / unit for domestic
+      equals 1430 kgCO2e / kg
+      set priorEquipment to 1000000 units during year 2025
+      set domestic to 20 mt during year 2025
+      retire 5 % / year
+      recharge 10 % with 0.15 kg / unit
+    end substance
+
+    uses substance "Low-GWP"
+      enable domestic
+      initial charge with 0.15 kg / unit for domestic
+      equals 3 kgCO2e / kg
+      set priorEquipment to 50000 units during year 2025
+      set sales to 1 mt during year 2025
+      retire 5 % / year
+      recharge 10 % with 0.15 kg / unit
+    end substance
+  
+  end application
+
+end default
+
+start policy "Cap Policy"
+
+  modify application "Test App"
+  
+    modify substance "High-GWP"
+      cap sales to 90 % displacing "Low-GWP" during years 2028 to onwards
+    end substance
+  
+  end application
+
+end policy
+
+start simulations
+
+  simulate "BAU"
+  from years 2025 to 2030
+
+  simulate "Cap with Displacement"
+    using "Cap Policy"
+  from years 2025 to 2030
+
+end simulations


### PR DESCRIPTION
This resolves an issue with use of the replace operation. In certain contexts, this mid-timestep change was causing issues with prior equipment calculation. This was isolated to human error in an earlier change during the beta test to support new features and fixes. Note that this write up is abbreviated as this fix is an extension of a prior change. A similar issue was found for cap but the change was accidentally not extended to replace.