### PR TITLE
Add fix for sticky demand.

### DIFF
--- a/engine/src/test/java/org/kigalisim/validate/CapLiveTests.java
+++ b/engine/src/test/java/org/kigalisim/validate/CapLiveTests.java
@@ -497,16 +497,12 @@ public class CapLiveTests {
 
     List<EngineResult> resultsList = results.collect(Collectors.toList());
 
-    // Get R-600a results for multiple years to understand the pattern
-    EngineResult r600a2026 = LiveTestsUtil.getResult(resultsList.stream(), 2026, "Domestic Refrigeration", "R-600a");
+    // Get R-600a results for 2027 and 2028
     EngineResult r600a2027 = LiveTestsUtil.getResult(resultsList.stream(), 2027, "Domestic Refrigeration", "R-600a");
     EngineResult r600a2028 = LiveTestsUtil.getResult(resultsList.stream(), 2028, "Domestic Refrigeration", "R-600a");
-    EngineResult r600a2029 = LiveTestsUtil.getResult(resultsList.stream(), 2029, "Domestic Refrigeration", "R-600a");
 
-    assertNotNull(r600a2026, "Should have result for R-600a in year 2026");
     assertNotNull(r600a2027, "Should have result for R-600a in year 2027");
     assertNotNull(r600a2028, "Should have result for R-600a in year 2028");
-    assertNotNull(r600a2029, "Should have result for R-600a in year 2029");
 
 
     // Calculate total consumption (domestic + import) for assertion
@@ -517,8 +513,8 @@ public class CapLiveTests {
 
     // This should fail if the bug exists - consumption should NOT decrease in 2028
     assertTrue(consumption2028 >= consumption2027,
-        String.format("R-600a consumption should not decrease from 2027 (%.6f kg) to 2028 (%.6f kg) " +
-                     "due to ongoing cap displacement", consumption2027, consumption2028));
+        String.format("R-600a consumption should not decrease from 2027 (%.6f kg) to 2028 (%.6f kg) "
+                     + "due to ongoing cap displacement", consumption2027, consumption2028));
   }
 
   /**

--- a/engine/src/test/java/org/kigalisim/validate/CapLiveTests.java
+++ b/engine/src/test/java/org/kigalisim/validate/CapLiveTests.java
@@ -497,22 +497,23 @@ public class CapLiveTests {
 
     List<EngineResult> resultsList = results.collect(Collectors.toList());
 
-    // Get R-600a results for 2027 and 2028
+    // Get R-600a results for multiple years to understand the pattern
+    EngineResult r600a2026 = LiveTestsUtil.getResult(resultsList.stream(), 2026, "Domestic Refrigeration", "R-600a");
     EngineResult r600a2027 = LiveTestsUtil.getResult(resultsList.stream(), 2027, "Domestic Refrigeration", "R-600a");
     EngineResult r600a2028 = LiveTestsUtil.getResult(resultsList.stream(), 2028, "Domestic Refrigeration", "R-600a");
+    EngineResult r600a2029 = LiveTestsUtil.getResult(resultsList.stream(), 2029, "Domestic Refrigeration", "R-600a");
 
+    assertNotNull(r600a2026, "Should have result for R-600a in year 2026");
     assertNotNull(r600a2027, "Should have result for R-600a in year 2027");
     assertNotNull(r600a2028, "Should have result for R-600a in year 2028");
+    assertNotNull(r600a2029, "Should have result for R-600a in year 2029");
 
-    // Calculate total consumption (domestic + import)
+
+    // Calculate total consumption (domestic + import) for assertion
     double consumption2027 = r600a2027.getDomesticConsumption().getValue().doubleValue()
                            + r600a2027.getImportConsumption().getValue().doubleValue();
     double consumption2028 = r600a2028.getDomesticConsumption().getValue().doubleValue()
                            + r600a2028.getImportConsumption().getValue().doubleValue();
-
-    // Log the values for debugging
-    System.out.printf("R-600a consumption 2027: %.6f kg%n", consumption2027);
-    System.out.printf("R-600a consumption 2028: %.6f kg%n", consumption2028);
 
     // This should fail if the bug exists - consumption should NOT decrease in 2028
     assertTrue(consumption2028 >= consumption2027,

--- a/engine/src/test/java/org/kigalisim/validate/CapLiveTests.java
+++ b/engine/src/test/java/org/kigalisim/validate/CapLiveTests.java
@@ -476,6 +476,51 @@ public class CapLiveTests {
   }
 
   /**
+   * Test sticky demand issue - consumption should not decrease in 2028.
+   * This test reproduces the issue where R-600a imports bump up in 2027 due to
+   * HFC-134a cap displacement but then revert back/decrease in 2028.
+   *
+   * <p>Expected: R-600a consumption in 2028 should be >= consumption in 2027
+   * since the cap displacement should continue. This test is designed to fail
+   * to demonstrate the issue.</p>
+   */
+  @Test
+  public void testStickyDemand() throws IOException {
+    // Load and parse the QTA file
+    String qtaPath = "../examples/sticky_demand.qta";
+    ParsedProgram program = KigaliSimFacade.parseAndInterpret(qtaPath);
+    assertNotNull(program, "Program should not be null");
+
+    // Run the "StickyDemand" scenario
+    String scenarioName = "StickyDemand";
+    Stream<EngineResult> results = KigaliSimFacade.runScenario(program, scenarioName, progress -> {});
+
+    List<EngineResult> resultsList = results.collect(Collectors.toList());
+
+    // Get R-600a results for 2027 and 2028
+    EngineResult r600a2027 = LiveTestsUtil.getResult(resultsList.stream(), 2027, "Domestic Refrigeration", "R-600a");
+    EngineResult r600a2028 = LiveTestsUtil.getResult(resultsList.stream(), 2028, "Domestic Refrigeration", "R-600a");
+
+    assertNotNull(r600a2027, "Should have result for R-600a in year 2027");
+    assertNotNull(r600a2028, "Should have result for R-600a in year 2028");
+
+    // Calculate total consumption (domestic + import)
+    double consumption2027 = r600a2027.getDomesticConsumption().getValue().doubleValue()
+                           + r600a2027.getImportConsumption().getValue().doubleValue();
+    double consumption2028 = r600a2028.getDomesticConsumption().getValue().doubleValue()
+                           + r600a2028.getImportConsumption().getValue().doubleValue();
+
+    // Log the values for debugging
+    System.out.printf("R-600a consumption 2027: %.6f kg%n", consumption2027);
+    System.out.printf("R-600a consumption 2028: %.6f kg%n", consumption2028);
+
+    // This should fail if the bug exists - consumption should NOT decrease in 2028
+    assertTrue(consumption2028 >= consumption2027,
+        String.format("R-600a consumption should not decrease from 2027 (%.6f kg) to 2028 (%.6f kg) " +
+                     "due to ongoing cap displacement", consumption2027, consumption2028));
+  }
+
+  /**
    * Test displacement scenario to verify total equipment population behavior.
    * This tests that the total equipment population for R-600a + HFC-134a in BAU and S1
    * should be the same in year 5 because we cap and displace in S1.

--- a/examples/sticky_demand.qta
+++ b/examples/sticky_demand.qta
@@ -1,0 +1,64 @@
+start default
+
+  define application "Domestic Refrigeration"
+
+    uses substance "HFC-134a"
+      enable import
+      initial charge with 0 kg / unit for domestic
+      initial charge with 0.15 kg / unit for import
+      initial charge with 0 kg / unit for export
+      equals 1430 kgCO2e / kg
+      equals 1 kwh / unit
+      set priorEquipment to 1,000,000 units during year 2025
+      set import to 100 mt during year 2025
+      change import by 5 % / year during years 2025 to 2030
+      change import by 3 % / year during years 2031 to 2035
+      retire 5 % / year
+      recharge 5 % with 0.15 kg / unit
+    end substance
+
+
+    uses substance "R-600a"
+      enable import
+      initial charge with 0 kg / unit for domestic
+      initial charge with 0.07 kg / unit for import
+      initial charge with 0 kg / unit for export
+      equals 3 kgCO2e / kg
+      equals 1 kwh / unit
+      set priorEquipment to 100,000 units during year 2025
+      set import to 10 mt during year 2025
+      change import by 5 % / year during years 2025 to 2030
+      change import by 3 % / year during years 2031 to 2035
+      retire 5 % / year
+      recharge 5 % with 0.07 kg / unit
+    end substance
+
+  end application
+
+end default
+
+
+start policy "StickyDemand"
+
+  modify application "Domestic Refrigeration"
+
+    modify substance "HFC-134a"
+      cap import to 80 mt displacing "R-600a" during years 2027 to onwards
+    end substance
+
+  end application
+
+end policy
+
+
+start simulations
+
+  simulate "Business as Usual"
+  from years 2025 to 2035
+
+
+  simulate "StickyDemand"
+    using "StickyDemand"
+  from years 2025 to 2035
+
+end simulations


### PR DESCRIPTION
Allow demand from an intervention to persist without continued intervention (demand coasting).